### PR TITLE
Fix excess space before dot, change "-" to "--"

### DIFF
--- a/glossarium.typ
+++ b/glossarium.typ
@@ -45,10 +45,7 @@ SOFTWARE.*/
           [#entry.short#suffix ]
         }
 
-        [
-        #link(label(entry.key))[#textLink]
-        #label(__glossary_label_prefix + entry.key)
-        ]
+        [#link(label(entry.key))[#textLink]#label(__glossary_label_prefix + entry.key)]
       } else {
         text(fill: red, "Glossary entry not found: " + key)
       }

--- a/glossarium.typ
+++ b/glossarium.typ
@@ -114,11 +114,12 @@ SOFTWARE.*/
 
                 {
                   set text(weight: 600)
-                  if hasLong [
-                  #emph(entry.short) - #entry.long
-                  ] else [
-                  #emph(entry.short)
-                  ]
+                  if hasLong {
+                    emph(entry.short) + [ -- ] + entry.long
+                  }
+                  else {
+                    emph(entry.short)
+                  }
                 }
                 if hasDesc [: #desc ] else [. ]
 

--- a/glossarium.typ
+++ b/glossarium.typ
@@ -42,7 +42,7 @@ SOFTWARE.*/
         let textLink = if (is_first or long == true) and entlong != [] and entlong != "" {
           [ #entry.short#suffix (#emph(entlong))]
         } else {
-          [#entry.short#suffix ]
+          [#entry.short#suffix]
         }
 
         [#link(label(entry.key))[#textLink]#label(__glossary_label_prefix + entry.key)]


### PR DESCRIPTION
Due to the content block spanning three lines in the `if hasLong` condition, there is excess whitespace present when no description is given.

Moreover, the single dash "-" does look a bit too tiny so I extended it to "---". 

Before:
![Screenshot 2023-10-07 at 12 51 14](https://github.com/ENIB-Community/glossarium/assets/20155974/1ac03c86-ad37-4617-84a7-0ab92693b14c)

Now:
![Screenshot 2023-10-07 at 12 51 04](https://github.com/ENIB-Community/glossarium/assets/20155974/09febef4-8c08-4fbf-b032-57a97ba3f3b0)
