### PR TITLE
Remove unnecessary spaces and support long: false

### DIFF
--- a/glossarium.typ
+++ b/glossarium.typ
@@ -40,17 +40,14 @@ SOFTWARE.*/
         let is_first = gloss == ();
         let entlong = entry.at("long", default: "")
         let textLink = if display !=none {
-            [ #display]
+            [#display]
         } else if (is_first or long == true) and entlong != [] and entlong != "" {
-          [ #entry.short#suffix (#emph(entlong))]
+          [#entry.short#suffix (#emph(entlong))]
         } else {
-          [#entry.short#suffix ]
+          [#entry.short#suffix]
         }
 
-        [
-        #link(label(entry.key))[#textLink]
-        #label(__glossary_label_prefix + entry.key)
-        ]
+        [#link(label(entry.key))[#textLink]#label(__glossary_label_prefix + entry.key)]
       } else {
         text(fill: red, "Glossary entry not found: " + key)
       }

--- a/glossarium.typ
+++ b/glossarium.typ
@@ -41,7 +41,7 @@ SOFTWARE.*/
         let entlong = entry.at("long", default: "")
         let textLink = if display !=none {
             [#display]
-        } else if (is_first or long == true) and entlong != [] and entlong != "" {
+        } else if (is_first or long == true) and entlong != [] and entlong != "" and long != false {
           [#entry.short#suffix (#emph(entlong))]
         } else {
           [#entry.short#suffix]


### PR DESCRIPTION
Remove unnecessary spaces after the `#gls("fpga"). blabla bla` as example. Using it in combination with a , or a . afterwards it generates an unnecessary space after the label.

![Screenshot 1](https://github.com/ENIB-Community/glossarium/assets/6866008/b99dcce2-a470-4680-bc30-a3fd9d611e28)

After this patch:

![Screenshot 2](https://github.com/ENIB-Community/glossarium/assets/6866008/5b379783-3354-4bff-ae89-13a2f9157e8d)

and support for long: false
if you are using
```rust
#gls("ddr-ram", long: false)
```
the `long: false` will not be ignored as it was before the patch