### PR TITLE
fix: prevent extra space after glossary item

### DIFF
--- a/glossarium.typ
+++ b/glossarium.typ
@@ -47,7 +47,7 @@ SOFTWARE.*/
           [#entry.short#suffix]
         }
 
-        [#link(label(entry.key))[#textLink]#label(__glossary_label_prefix + entry.key)]
+        [#link(label(entry.key), textLink)#label(__glossary_label_prefix + entry.key)]
       } else {
         text(fill: red, "Glossary entry not found: " + key)
       }
@@ -151,4 +151,3 @@ SOFTWARE.*/
     ]
   }
 };
-


### PR DESCRIPTION
Related discussions:

- https://discord.com/channels/1054443721975922748/1088371919725793360/1174372884844646440
- https://discord.com/channels/1054443721975922748/1088371919725793360/1179905527476662423

Commit credits: @dherse