### PR TITLE
README: add missing comma to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Then the terms are passed as a list to `print-glossary`
     short: "OIDC", 
     long: "OpenID Connect", 
     desc: [OpenID is an open standard and decentralized authentication protocol promoted by the non-profit
-     #link("https://en.wikipedia.org/wiki/OpenID#OpenID_Foundation")[OpenID Foundation].]
+     #link("https://en.wikipedia.org/wiki/OpenID#OpenID_Foundation")[OpenID Foundation].],
     group: "Accronyms",
   ),
 ))


### PR DESCRIPTION
Copying over the example given in the `README` file, I noticed that there is a comma missing, causing a document not to compile. This PR fixes this minor issue.